### PR TITLE
Add GPG Key badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="https://www.linkedin.com/in/aliciasykes" title="LinkedIn - Alicia Sykes"><img src="https://img.shields.io/badge/-Alicia_Sykes-0072b1?style=flat&logo=inspire&logoColor=white" /></a>
   <a href="https://www.reddit.com/user/lissy93" title="Reddit - u/lissy93"><img src="https://img.shields.io/badge/-Lissy93-ff4500?style=flat&logo=reddit&logoColor=white" /></a>
   <a href="https://aliciasykes.com" title="Personal Website - aliciasykes.com"><img src="https://img.shields.io/badge/-aliciasykes.com-00CCB4?style=flat&logo=ApacheSpark&logoColor=white" /></a>
+  <a href="https://github.com/Lissy93.gpg" title="GPG Key"><img src="https://gpg-badge.hesreallyhim.com/Lissy93.svg?style=flat" alt="GPG Key" /></a>
   </kbd>
 </p>
 


### PR DESCRIPTION
Hi there!

I like to check out people's creative GitHub profiles. I noticed you have a GPG key on your GitHub account - nice job! That's actually pretty rare.

In order to promote and encourage GPG key usage and commit-signing on GitHub, I've built a small badge service that shows others that you have a publicly visible GPG key (in case you didn't know, GitHub automatically provides a link to users' GPG keys at github.com/USERNAME.gpg).

All this badge does is check that public link to see if there's a GPG key there - no tracking, no revenue involved, just a small way to signal that you care about promoting security on GitHub.

In case you're interested, but you don't like the look, there's also a little demo page where you can check out some other styles: https://demo.gpg-badge.hesreallyhim.com/

If you're not interested, feel free to close the PR - no hard feelings! Just trying to spread awareness about security and keys on GitHub. I hope this PR is not a nuisance, and thanks either way for contributing to a positive security culture on GitHub.